### PR TITLE
Fix passing navigation arguments to destination fragment

### DIFF
--- a/app/src/main/java/com/star_zero/navigation_keep_fragment_sample/navigation/KeepStateNavigator.kt
+++ b/app/src/main/java/com/star_zero/navigation_keep_fragment_sample/navigation/KeepStateNavigator.kt
@@ -40,6 +40,7 @@ class KeepStateNavigator(
         } else {
             transaction.attach(fragment)
         }
+        fragment.arguments = args
 
         transaction.setPrimaryNavigationFragment(fragment)
         transaction.setReorderingAllowed(true)


### PR DESCRIPTION
This also prevents the app from crashing when the destination fragment has arguments.